### PR TITLE
Update `cli-cmd-wifi.c`, fix bug in mac address print statement after wifi scanning

### DIFF
--- a/apps/abeeway/app-abw-demo/src/cli-cmd-wifi.c
+++ b/apps/abeeway/app-abw-demo/src/cli-cmd-wifi.c
@@ -127,7 +127,7 @@ static cli_parser_status_t _cmd_lr1110_wifi_scan(void *arg, int argc, char *argv
 
 		cli_printf(" MAC Address: 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x, RSSI: %d\n",
 				r.mac_address[0], r.mac_address[1],r.mac_address[2],
-				r.mac_address[3], r.mac_address[4], r.mac_address[4], r.rssi);
+				r.mac_address[3], r.mac_address[4], r.mac_address[5], r.rssi);
 	}
 	return cli_parser_status_ok;
 }
@@ -179,7 +179,7 @@ static cli_parser_status_t _cmd_lr1110_wifi_results(void *arg, int argc, char *a
 		cli_printf("Entry %d\n", i);
 		cli_printf(" MAC Address: 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x\n",
 				r.mac_address[0], r.mac_address[1],r.mac_address[2],
-				r.mac_address[3], r.mac_address[4], r.mac_address[4]);
+				r.mac_address[3], r.mac_address[4], r.mac_address[5]);
 		cli_printf(" RSSI: %d\n", r.rssi);
 
 		lr1110_wifi_channel_t channel;

--- a/apps/community/app-cmty_ble-geoloc/src/cli-cmd-wifi.c
+++ b/apps/community/app-cmty_ble-geoloc/src/cli-cmd-wifi.c
@@ -127,7 +127,7 @@ static cli_parser_status_t _cmd_lr11xx_wifi_scan(void *arg, int argc, char *argv
 
 		cli_printf(" MAC Address: 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x, RSSI: %d\n",
 				r.mac_address[0], r.mac_address[1],r.mac_address[2],
-				r.mac_address[3], r.mac_address[4], r.mac_address[4], r.rssi);
+				r.mac_address[3], r.mac_address[4], r.mac_address[5], r.rssi);
 	}
 	return cli_parser_status_ok;
 }
@@ -179,7 +179,7 @@ static cli_parser_status_t _cmd_lr11xx_wifi_results(void *arg, int argc, char *a
 		cli_printf("Entry %d\n", i);
 		cli_printf(" MAC Address: 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x\n",
 				r.mac_address[0], r.mac_address[1],r.mac_address[2],
-				r.mac_address[3], r.mac_address[4], r.mac_address[4]);
+				r.mac_address[3], r.mac_address[4], r.mac_address[5]);
 		cli_printf(" RSSI: %d\n", r.rssi);
 
 		lr11xx_wifi_channel_t channel;

--- a/apps/community/app-cmty_cli/src/cli/cli-cmd-wifi.c
+++ b/apps/community/app-cmty_cli/src/cli/cli-cmd-wifi.c
@@ -127,7 +127,7 @@ static cli_parser_status_t _cmd_lr11xx_wifi_scan(void *arg, int argc, char *argv
 
 		cli_printf(" MAC Address: 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x, RSSI: %d\n",
 				r.mac_address[0], r.mac_address[1],r.mac_address[2],
-				r.mac_address[3], r.mac_address[4], r.mac_address[4], r.rssi);
+				r.mac_address[3], r.mac_address[4], r.mac_address[5], r.rssi);
 	}
 	return cli_parser_status_ok;
 }
@@ -179,7 +179,7 @@ static cli_parser_status_t _cmd_lr11xx_wifi_results(void *arg, int argc, char *a
 		cli_printf("Entry %d\n", i);
 		cli_printf(" MAC Address: 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x\n",
 				r.mac_address[0], r.mac_address[1],r.mac_address[2],
-				r.mac_address[3], r.mac_address[4], r.mac_address[4]);
+				r.mac_address[3], r.mac_address[4], r.mac_address[5]);
 		cli_printf(" RSSI: %d\n", r.rssi);
 
 		lr11xx_wifi_channel_t channel;


### PR DESCRIPTION
Bug fix where the mac address had the first and second byte duplicated. Replaced r.mac_address[4] with r.mac_address[5] at lines 130 and 182.